### PR TITLE
add Typescript module definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,74 @@
+// Type definitions for react-native-survey-monkey
+// Project: https://github.com/yarikpwnzer/react-native-survey-monkey
+// Definitions by: Alan Soares <github.com/alanrsoares>
+
+export interface ResponseAnswer {
+  row_id: number;
+  row_index: number;
+  row_value: string;
+}
+
+export interface ResponseItem {
+  page_index: number;
+  question_value: string;
+  question_index: number;
+  question_id: number;
+  page_id: number;
+  answers: ResponseAnswer[];
+}
+
+export interface SurveyMonkeyError {
+  code: string;
+  description: string;
+  fullDescription: string;
+}
+export interface Respondent {
+  completion_status: string;
+  responses: ResponseItem[];
+}
+
+export interface SurveyMonkeyResponse {
+  respondent: null | Respondent;
+  error: null | SurveyMonkeyError;
+  target: number;
+}
+
+export interface SurveyMonkeyProps {
+  /**
+   * Callback invoked once the survey is ended, whether completed or not
+   */
+  onRespondentDidEndSurvey?: (response: SurveyMonkeyResponse) => void;
+  /**
+   * Only available on iOS, android doesn't use a title bar for webviews
+   */
+  cancelButtonTintColor?: string;
+}
+
+export interface ConfirmDialogConfig {
+  title: string;
+  body: string;
+  positiveActionTitle: string;
+  cancelTitle: string;
+  afterInstallInterval: number;
+  afterAcceptInterval: number;
+  afterDeclineInterval: number;
+}
+
+declare class SurveyMonkey extends React.PureComponent<SurveyMonkeyProps> {
+  /**
+   * Shows the survey associated with the collectorHash
+   *
+   * @param collectorHash - hash generated for the SurveyMonkey mobile SDK
+   * @param customVariables
+   * @param customTitle
+   * @param confirmDialogParams
+   */
+  public showSurveyMonkey(
+    collectorHash: string,
+    customVariables?: null | Record<string, string>,
+    customTitle?: null | string,
+    confirmDialogParams?: Partial<ConfirmDialogConfig>
+  ): void;
+}
+
+export default SurveyMonkey;

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Yaroslav Fuchko",
   "license": "MIT",
   "devDependencies": {
+    "@types/react": "^16.9.17",
     "react-native": "0.61.4"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -848,6 +848,19 @@
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
+"@types/react@^16.9.17":
+  version "16.9.17"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.17.tgz#58f0cc0e9ec2425d1441dd7b623421a867aa253e"
+  integrity sha512-UP27In4fp4sWF5JgyV6pwVPAQM83Fj76JOcg02X5BZcpSu5Wx+fP9RMqc2v0ssBoQIFvD5JdKY41gjJJKmw6Bg==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -1522,6 +1535,11 @@ cross-spawn@^6.0.0:
     semver "^5.5.0"
     shebang-command "^1.2.0"
     which "^1.2.9"
+
+csstype@^2.2.0:
+  version "2.6.8"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.8.tgz#0fb6fc2417ffd2816a418c9336da74d7f07db431"
+  integrity sha512-msVS9qTuMT5zwAGCVm4mxfrZ18BNc6Csd0oJAtiFMZ1FAx1CCvy2+5MDmYoix63LM/6NDbNtodCiGYGmFgO0dA==
 
 dayjs@^1.8.15:
   version "1.8.17"


### PR DESCRIPTION
I came across this library today when needing to integrate the SurveyMonkey SDK on a React Native project. Then noticed there were no typescript definitions available. So instead of publishing the definitions to @DefinitelyTyped I decided to contribute back to the original repository.

I'm happy to help with future type updates.