### PR TITLE
fix: Xcode 12 compatibility

### DIFF
--- a/react-native-survey-monkey.podspec
+++ b/react-native-survey-monkey.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/*.{h,m}'
 
-  s.dependency 'React'
+  s.dependency 'React-Core'
   s.dependency 'surveymonkey-ios-sdk', '~> 2.0'
 end


### PR DESCRIPTION
# Summary

Latest Xcode 12 fails to build while without a module to depend on React-Core directly hence this change is necessary for all native modules on iOS. This change requires React Native 0.60.2 or newer. For more details please check: facebook/react-native#29633 (comment)