### PR TITLE
chore: remove usage of jcenter()

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ def safeExtGet(prop, fallback) {
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         google()
     }
 
@@ -32,7 +32,6 @@ android {
 
 repositories {
     mavenCentral()
-    jcenter()
     google()
 //    maven {
 //        // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm


### PR DESCRIPTION
# Info

I got a warning message about shuting down jcenter.

    WARNING:: Please remove usages of jcenter() Maven repository from your build scripts and migrate your build to other Maven repositories.
    This repository is deprecated and it will be shut down in the future.
    See http://developer.android.com/r/tools/jcenter-end-of-service for more information.

Using this information we can drop this repo from gradle file.