### PR TITLE
issue 24 onRespondentDidEndSurvey isn't called on Android fix

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,13 @@
-
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.surveymonkey">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.surveymonkey">
+
+    <application android:allowBackup="true">
+        <activity
+            android:name="com.surveymonkey.surveymonkeyandroidsdk.SMFeedbackActivity"
+            android:exported="false"
+            tools:node="merge" />
+    </application>
 
 </manifest>

--- a/android/src/main/java/com/surveymonkey/RNSurveyMonkeyModule.java
+++ b/android/src/main/java/com/surveymonkey/RNSurveyMonkeyModule.java
@@ -166,7 +166,7 @@ public class RNSurveyMonkeyModule extends ReactContextBaseJavaModule {
     private final ActivityEventListener activityEventListener = new ActivityEventListener() {
         @Override
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-            if (requestCode != REQUEST_CODE || resultCode == Activity.RESULT_CANCELED || data == null)
+            if (requestCode != REQUEST_CODE || data == null)
                 return;
 
             if (resultCode == Activity.RESULT_OK) {

--- a/android/src/main/java/com/surveymonkey/RNSurveyMonkeyModule.java
+++ b/android/src/main/java/com/surveymonkey/RNSurveyMonkeyModule.java
@@ -166,8 +166,10 @@ public class RNSurveyMonkeyModule extends ReactContextBaseJavaModule {
     private final ActivityEventListener activityEventListener = new ActivityEventListener() {
         @Override
         public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
-            if (requestCode != REQUEST_CODE || data == null)
+            if (requestCode != REQUEST_CODE || data == null) {
+                resolvePromise(null);
                 return;
+            }
 
             if (resultCode == Activity.RESULT_OK) {
                 String respondent = data.getStringExtra("smRespondent");


### PR DESCRIPTION
fixes the issue described in #24. The promise should resolve even if error states for the app to be able to receive an update.
if result code is equal with `Activity.RESULT_CANCELED` the user might not have the feature to get the responses of the survey but still can get the error produced 