### PR TITLE
Fix SurveyMonkey Android SDK manifest

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,13 @@
-
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.surveymonkey">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.surveymonkey">
+
+    <application android:allowBackup="true">
+        <activity
+            android:name="com.surveymonkey.surveymonkeyandroidsdk.SMFeedbackActivity"
+            android:exported="false"
+            tools:node="merge" />
+    </application>
 
 </manifest>


### PR DESCRIPTION
Hello! According to the [Google Play's target API level requirement](https://developer.android.com/google/play/requirements/target-sdk),
> Starting in November 2022, app updates must target API level 31 or above and adjust for behavioral changes in Android 12.

Looking at the section [Migrate from Android 11 (API level 30) to Android 12 (API level 31)](https://developer.android.com/google/play/requirements/target-sdk#pre12), there is a point about Intent filters.
> Intent filters: If your app contains [activities](https://developer.android.com/guide/components/activities/intro-activities), [services](https://developer.android.com/guide/components/services), or [broadcast receivers](https://developer.android.com/guide/components/broadcasts) that use [intent filters](https://developer.android.com/guide/components/intents-filters#Receiving), you must explicitly declare the [android:exported](https://developer.android.com/guide/topics/manifest/activity-element#exported) attribute for these components.

I did explicitly declare the `android:exported` attribute for all the components of the app beforehand as it has been a best-practice for Android development and even recommended by Google in the documentation for long time.

If you set the `targetSdkVersion` to `31` then builds fail because of `react-native-survey-monkey`. You will see a generic message `Manifest merger failed with multiple errors, see logs`.
<img width="511" alt="image" src="https://user-images.githubusercontent.com/16272113/194909145-67f89131-1b79-4c6a-ba76-e5f5ee3da6ce.png">
Running Gradle with the `--info` flag helps as it logs the task and manifest merger steps.
<img width="1151" alt="image" src="https://user-images.githubusercontent.com/16272113/194909438-26e1f2f1-23c3-47b0-b3d1-890e721a8c9d.png">
Here you go, the last one before a fail is `com.surveymonkey:surveymonkey-android-sdk:2.0.0`, specifically `com.surveymonkey.surveymonkeyandroidsdk.SMFeedbackActivity`.

The problem with the abandoned SurveyMonkey Mobile SDK is that the `android:exported` attribute is not declared in the manifest and probably never will, thus we have to add it by ourselves. We don't have the source code of the SDK because it is distributed as an [AAR](https://developer.android.com/studio/projects/android-library) (Android library), look at the [surveymonkey-android-sdk](https://github.com/SurveyMonkey/surveymonkey-android-sdk/blob/master/surveymonkey_android_sdk.aar) repository.

Luckily, we have an ability to manage Manifest files with build tools. All the manifest files are combined into one file. We can tweak the SurveyMonkey Android SDK manifest with the `merge` [node marker](https://developer.android.com/studio/build/manage-manifests#node_markers) to add the required `android:exported` attribute.

TLDR: I added the now required `android:exported` attribute to the SurveyMonkey Android SDK manifest.